### PR TITLE
Make fetcher work with new jenkins builds by adding s3prefix fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Example URLs:
 http://www.example.com/artifact.zip
 https://www.example.com/artifact.zip
 s3://mybucket/prefix/artifact.zip
+s3prefix://mybucket/prefix?pattern=^.*.zip$&sortmethod=version
+s3prefix://mybucket/prefix?pattern=^.*.zip$&sortmethod=newest
+file://directory/artifact.zip
 jenkins://mybucket/myjob (downloads WAR artifact from latest build of job)
 jenkins://mybucket/myjob?pattern=^.*\.whl$ (downloads artifact matching given pattern from latest build of job)
 schemabackup://mybucket/myhost/mydatabase/myschema (downloads latest backup timestamp)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 INSTALL_REQUIRES = [
         'boto3>=1.9.161',
         'fasteners==0.14.1',
-        'requests>=2.22.0'
+        'requests>=2.22.0',
+        'packaging'
     ]
 
 TESTS_REQUIRE = [

--- a/tests/test_aodnfetcher.py
+++ b/tests/test_aodnfetcher.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from datetime import datetime
 
 import botocore.exceptions
 import mock
@@ -473,9 +474,9 @@ class TestPrefixS3Fetcher(unittest.TestCase):
 
         fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
             [
-                {'Key': 'prefix/1/version1.war', 'LastModified': '2020-07-29 05:41:27+00:00'},
-                {'Key': 'prefix/2/version2.war', 'LastModified': '2019-07-29 05:41:27+00:00'},
-                {'Key': 'prefix/3/version3.war', 'LastModified': '2018-07-29 05:41:27+00:00'}
+                {'Key': 'prefix/1/version1.war', 'LastModified': datetime(2020, 7, 29, 5, 41, 27)},
+                {'Key': 'prefix/2/version2.war', 'LastModified': datetime(2019, 7, 29, 5, 41, 27)},
+                {'Key': 'prefix/3/version3.war', 'LastModified': datetime(2018, 7, 29, 5, 41, 27)}
             ]
         ]
 

--- a/tests/test_aodnfetcher.py
+++ b/tests/test_aodnfetcher.py
@@ -375,11 +375,11 @@ class TestPrefixS3Fetcher(unittest.TestCase):
         }
 
         self.fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
-            [{'Key': 'prefix/1/path1.war', 'LastModified': '2011-07-29 05:41:27+00:00'},
-             {'Key': 'prefix/2/path2.war', 'LastModified': '2012-07-29 05:41:27+00:00'}
+            [{'Key': 'prefix/1/path1.war', 'LastModified': datetime(2011, 7, 29, 5, 41, 27)},
+             {'Key': 'prefix/2/path2.war', 'LastModified': datetime(2012, 7, 29, 5, 41, 27)}
             ],
-            [{'Key': 'prefix/3/path1.war', 'LastModified': '2013-07-29 05:41:27+00:00'},
-             {'Key': 'prefix/4/path2.war', 'LastModified': '2014-07-29 05:41:27+00:00'}
+            [{'Key': 'prefix/3/path1.war', 'LastModified': datetime(2013, 7, 29, 5, 41, 27)},
+             {'Key': 'prefix/4/path2.war', 'LastModified': datetime(2014, 7, 29, 5, 41, 27)}
             ]
         ]
 
@@ -427,9 +427,9 @@ class TestPrefixS3Fetcher(unittest.TestCase):
 
         fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
             [
-                {'Key': 'prefix/1/path1.war', 'LastModified': '2020-07-29 05:41:27+00:00'},
-                {'Key': 'prefix/2/path2.whl', 'LastModified': '2019-07-29 05:41:27+00:00'},
-                {'Key': 'prefix/3/path3.whl', 'LastModified': '2018-07-29 05:41:27+00:00'}
+                {'Key': 'prefix/1/path1.war', 'LastModified': datetime(2020, 7, 29, 5, 41, 27)},
+                {'Key': 'prefix/2/path2.whl', 'LastModified': datetime(2019, 7, 29, 5, 41, 27)},
+                {'Key': 'prefix/3/path3.whl', 'LastModified': datetime(2018, 7, 29, 5, 41, 27)}
             ]
         ]
 
@@ -443,7 +443,7 @@ class TestPrefixS3Fetcher(unittest.TestCase):
 
         fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
             [
-                {'Key': 'prefix/2/path2.whl', 'LastModified': '2019-07-29 05:41:27+00:00'}
+                {'Key': 'prefix/2/path2.whl', 'LastModified': datetime(2020, 7, 29, 5, 41, 27)}
             ]
         ]
 
@@ -458,9 +458,9 @@ class TestPrefixS3Fetcher(unittest.TestCase):
 
         fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
             [
-                {'Key': 'prefix/1/version1.war', 'LastModified': '2020-07-29 05:41:27+00:00'},
-                {'Key': 'prefix/2/version2.war', 'LastModified': '2019-07-29 05:41:27+00:00'},
-                {'Key': 'prefix/3/version3.war', 'LastModified': '2018-07-29 05:41:27+00:00'}
+                {'Key': 'prefix/1/version1.war', 'LastModified': datetime(2020, 7, 29, 5, 41, 27)},
+                {'Key': 'prefix/2/version2.war', 'LastModified': datetime(2019, 7, 29, 5, 41, 27)},
+                {'Key': 'prefix/3/version3.war', 'LastModified': datetime(2018, 7, 29, 5, 41, 27)}
             ]
         ]
 

--- a/tests/test_aodnfetcher.py
+++ b/tests/test_aodnfetcher.py
@@ -354,6 +354,102 @@ class TestJenkinsS3Fetcher(unittest.TestCase):
         self.assertEqual(fetcher.local_file_hint, 'custom_path.whl')
 
 
+class TestPrefixS3Fetcher(unittest.TestCase):
+    def setUp(self):
+        self.url = 's3prefix://bucket/prefix_part_1/prefix_part_2'
+        self.fetcher = get_mocked_s3_fetcher(self.url)
+
+        self.mock_content = b'mock content'
+        self.mock_etag = 'abc123'
+        mock_body = mock.MagicMock()
+        mock_body.read.return_value = self.mock_content
+
+        self.fetcher.s3_client.get_object.return_value = {
+            'Body': mock_body,
+            'ResponseMetadata': {
+                'HTTPHeaders': {
+                    'etag': self.mock_etag
+                }
+            }
+        }
+
+        self.fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
+            [{'Key': 'prefix/1/path1.war', 'LastModified': '2011-07-29 05:41:27+00:00'},
+             {'Key': 'prefix/2/path2.war', 'LastModified': '2012-07-29 05:41:27+00:00'}
+            ],
+            [{'Key': 'prefix/3/path1.war', 'LastModified': '2013-07-29 05:41:27+00:00'},
+             {'Key': 'prefix/4/path2.war', 'LastModified': '2014-07-29 05:41:27+00:00'}
+            ]
+        ]
+
+        self.fetcher.s3_client.list_objects_v2.__self__ = self.fetcher.s3_client
+        self.fetcher.s3_client.list_objects_v2.__name__ = 'list_objects_v2'
+
+    def test_handle(self):
+        content = self.fetcher.handle.read()
+        self.assertEqual(content, self.mock_content)
+
+    def test_real_url(self):
+        self.assertEqual(self.fetcher.real_url, 's3://bucket/prefix/4/path2.war')
+
+    def test_unique_id(self):
+        unique_id = self.fetcher.unique_id
+        self.assertEqual(unique_id, self.mock_etag)
+
+    def test_auth_failure(self):
+        self.fetcher.s3_client.get_object.side_effect = botocore.exceptions.ClientError(
+            {'Error': {'Code': 'AuthorizationHeaderMalformed'}}, 'GetObject')
+        with self.assertRaises(aodnfetcher.fetcherlib.AuthenticationError):
+            _ = self.fetcher.object
+
+    def test_no_builds(self):
+        self.fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = []
+
+        with self.assertRaises(aodnfetcher.fetcherlib.KeyResolutionError) as cm:
+            _ = self.fetcher.object
+        self.assertEqual(cm.exception.reason_code, 'NO_RESULTS')
+
+    def test_no_matching_keys(self):
+        self.fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
+            [{'Key': 'prefix/3/path3.txt'}]
+        ]
+
+        with self.assertRaises(aodnfetcher.fetcherlib.KeyResolutionError) as cm:
+            _ = self.fetcher.object
+        self.assertEqual(cm.exception.reason_code, 'NO_MATCHING_KEYS')
+
+    def test_custom_jenkins_pattern(self):
+        url = 's3prefix://bucket/prefix?pattern=^.*\.whl$'
+        fetcher = get_mocked_s3_fetcher(url)
+        fetcher.s3_client.list_objects_v2.__self__ = fetcher.s3_client
+        fetcher.s3_client.list_objects_v2.__name__ = 'list_objects_v2'
+
+        fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
+            [
+                {'Key': 'prefix/1/path1.war', 'LastModified': '2020-07-29 05:41:27+00:00'},
+                {'Key': 'prefix/2/path2.whl', 'LastModified': '2019-07-29 05:41:27+00:00'},
+                {'Key': 'prefix/3/path3.whl', 'LastModified': '2018-07-29 05:41:27+00:00'}
+            ]
+        ]
+
+        self.assertEqual(fetcher.real_url, 's3://bucket/prefix/2/path2.whl')
+
+    def test_custom_jenkins_pattern_to_local_file(self):
+        url = 's3prefix://bucket/job?pattern=^.*\.whl$&local_file=custom_path.whl'
+        fetcher = get_mocked_s3_fetcher(url)
+        fetcher.s3_client.list_objects_v2.__self__ = fetcher.s3_client
+        fetcher.s3_client.list_objects_v2.__name__ = 'list_objects_v2'
+
+        fetcher.s3_client.get_paginator().paginate().result_key_iters.return_value = [
+            [
+                {'Key': 'prefix/2/path2.whl', 'LastModified': '2019-07-29 05:41:27+00:00'}
+            ]
+        ]
+
+        self.assertEqual(fetcher.real_url, 's3://bucket/prefix/2/path2.whl')
+        self.assertEqual(fetcher.local_file_hint, 'custom_path.whl')
+
+
 class TestSchemaBackupS3Fetcher(unittest.TestCase):
     def setUp(self):
         self.list_objects_side_effect = [


### PR DESCRIPTION
EDIT: This has been updated based on feedback and is now ready to be reviewed and merged https://github.com/aodn/backlog/issues/1181

_Original Comments:_
Note that this is just a draft. Tests are broken and it can't be merged anyway since it breaks pre-existing jenkins functionality.

I've included a main entry point to show it functioning. As can be seen there, this would work with the current jenkins, if we slightly changed the ruby fetcher and the cloud-deploy vars files to include the full prefix.

This draft implementation requires the full S3 prefix whereas the pre-existing implementation only requires the bucket name and jobname, with a hardcoded prefix. Prefix is "jobs" in old jenkins and would be "promoted" in new jenkins. I see no reason why this should be hardcoded into the fetcher, especially when we're not hardcoding the bucket.

I'm thinking it might be good to just remove the concept of jenkins entirely from the fetcher and have this as a base s3 functionality, since it's just working off s3 keys and prefixes anyway. So there'd be two types of s3 fetchers, one would recieve a path pointing directly to a file, the other would receive a path pointing to a prefix and would output the latest matching file from under that prefix.